### PR TITLE
ENH: Comment out unused variable

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -7,6 +7,7 @@ jobs:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.0
     with:
       itk-cmake-options: '-DModule_MorphologicalContourInterpolation_BUILD_EXAMPLES:BOOL=ON'
+      itk-module-deps: 'RLEImage@v1.0.2'
 
   python-build-workflow:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.0

--- a/test/itkMorphologicalContourInterpolationTest.cxx
+++ b/test/itkMorphologicalContourInterpolationTest.cxx
@@ -33,14 +33,6 @@ doTest( std::string inFilename, std::string outFilename, bool UseDistanceTransfo
 
   typename ImageType::Pointer test = reader->GetOutput();
 
-  // region for partial coverage
-  typename ImageType::RegionType reg = test->GetLargestPossibleRegion();
-  // for (int i = 0; i < ImageType::ImageDimension; i++)
-  //  {
-  //  reg.GetModifiableIndex()[i] += (reg.GetSize(i) - 1) / 4;
-  //  reg.SetSize(i, (reg.GetSize(i) + 1) / 2);
-  //  }
-
   using mciType = itk::MorphologicalContourInterpolator< ImageType >;
   typename mciType::Pointer mci = mciType::New();
   mci->SetInput( test );


### PR DESCRIPTION
Comment out unused variable: getting the largest possible region of the superclass (`ImageToImageFilter`) is most likely being exercised in ITK proper.

Keep the commented code in case it is found to be useful when revisiting it in the future.

Fixes:
```
test/itkMorphologicalContourInterpolationTest.cxx:37:34:
 warning: unused variable 'reg' [-Wunused-variable]
   37 |   typename ImageType::RegionType reg = test->GetLargestPossibleRegion();
      |                                  ^~~
```

raised for example in:
https://open.cdash.org/viewBuildError.php?type=1&buildid=10154304