### PR TITLE
ENH: Bump wasm package versions to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itk-wasm/morphological-contour-interpolation-build",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "npm scripts to generate itk-wasm artifacts.",
   "private": true,
   "type": "module",

--- a/wasm/typescript/package.json
+++ b/wasm/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itk-wasm/morphological-contour-interpolation",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "packageManager": "pnpm@10.5.2",
   "description": "N-D morphology-based approach for interslice interpolation of anatomical slices from volumetric images.",
   "type": "module",


### PR DESCRIPTION
Python versions are also bumped after building and `pnpm
build:python:versionSync`.
