### PR TITLE
ENH: Bump Python package to build against ITK 5.4.4

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -4,13 +4,13 @@ on: [push,pull_request]
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.2
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.4
     with:
       itk-cmake-options: '-DModule_MorphologicalContourInterpolation_BUILD_EXAMPLES:BOOL=ON'
       itk-module-deps: 'RLEImage@v1.0.2'
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.2
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.4
     with:
       test-notebooks: false
     secrets:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "itk-morphologicalcontourinterpolation"
-version = "2.1.0"
+version = "2.1.1"
 description = "A morphology-based approach for interslice interpolation of anatomical slices from volumetric images."
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -33,7 +33,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "itk == 5.4.*",
 ]


### PR DESCRIPTION
Requires Python 3.9 or newer.
